### PR TITLE
Azure Storage Access

### DIFF
--- a/cms/enterprise-cms/cms/settings/production.py
+++ b/cms/enterprise-cms/cms/settings/production.py
@@ -73,12 +73,14 @@ if AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY:
             "account_key": AZURE_ACCOUNT_KEY,
             "overwrite_files": True,
             "azure_ssl": True,
+            "expiration_secs": 3600,  # URLs expire after 1 hour
+            "custom_domain": None,  # Don't use custom domain for private storage
         },
     }
     
     # Media files configuration with Azure Blob Storage (private)
     AZURE_MEDIA_CONTAINER = 'media'
-    # Serve media files through Django instead of direct Azure URLs
+    # Serve media files through Django instead of direct Azure URLs for private storage
     MEDIA_URL = '/media/'
     
     # Custom storage class for private Azure media files


### PR DESCRIPTION
This pull request updates the Azure Blob Storage configuration for media files in the production settings. The main changes clarify how private media files are served and add new configuration options for security and domain handling.

Azure Blob Storage configuration updates:

* Added the `expiration_secs` setting to set signed URL expiration to 1 hour, improving security for private file access.
* Set `custom_domain` to `None` to ensure private storage does not use a custom domain, which helps prevent unintended public exposure.

Documentation and clarity:

* Updated comments to clarify that media files are served through Django for private storage, not directly via Azure URLs.…ion and custom domain settings